### PR TITLE
improve caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ npm-debug.log
 yarn-error.log
 testem.log
 /typings
+*debug.log
 
 # System Files
 .DS_Store

--- a/firebase.json
+++ b/firebase.json
@@ -5,11 +5,7 @@
   },
   "hosting": {
     "public": "dist/lokalkauf-frontend",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ],
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       {
         "source": "/sitemaps/sitemaps.xml",
@@ -31,22 +27,32 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "/{,index.html}",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/ngsw.json",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
+      }
     ]
   },
   "storage": {
     "rules": "storage.rules"
   },
-  "functions": {
-    "predeploy": [
-      "npm --prefix \"$RESOURCE_DIR\" run lint",
-      "npm --prefix \"$RESOURCE_DIR\" run build"
-    ],
-    "source": "functions"
-  },
   "emulators": {
-    "functions": {
-      "port": 5001
-    },
     "firestore": {
       "port": 8080
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "ng serve --ssl true",
     "emulators:setup": "firebase setup:emulators:firestore",
-    "emulators": "firebase emulators:start",
+    "emulators": "firebase emulators:start --only=hosting,firestore",
     "build": "ng build --prod"
   },
   "private": true,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -131,6 +131,7 @@ const routes: Routes = [
     MatPasswordStrengthModule.forRoot(),
     ServiceWorkerModule.register('ngsw-worker.js', {
       enabled: environment.production,
+      registrationStrategy: 'registerImmediately',
     }),
     LightboxModule,
   ],


### PR DESCRIPTION
This should improve the caching behaviour (#67). The service worker is now registered immediately. What I found out is, the service worker always responds with the cached app. Just after that it looks for a new version and puts it into the cache. So there needs to be another page reload to display the new version.

**TLDR**: The app needs to be loaded 2 times to show the  new version.