### PR TITLE
firestore/storage rules/indexes rem. from deploymt

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Deploy
       uses: w9jds/firebase-action@v1.3.0
       with:
-        args: deploy -P production --only hosting,storage,firestore:rules
+        args: deploy -P production --only hosting
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Deploy
       uses: w9jds/firebase-action@v1.3.0
       with:
-        args: deploy -P staging --only hosting,storage,firestore:rules
+        args: deploy -P staging --only hosting
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
 


### PR DESCRIPTION
I took firestore and storage out of the deployment:

     args: deploy -P staging --only hosting

in the firebase.json the storage and the firestore configuration has remained. Theoretically, that should get out, too. If you accidentally deploy without --only, the settings are still used. 
I was just not sure about the emulator, maybe it needs that. Otherwise the backend emulator should be started from the lokalkauf-functions repository or something like that. 

It is important that the frontend deployment should not deploy backend stuff.