### PR TITLE
Change measurementId for the new Analytics Account

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -9,7 +9,7 @@ export const environment = {
     apiKey: 'AIzaSyBPUxq7muZ6N09BQfoRpTpVZUceki0mmTo',
     authDomain: 'lokalkauf-271814.firebaseapp.com',
     messagingSenderId: '167060133004',
-    measurementId: 'G-WJ6XGZ3RP5',
+    measurementId: 'G-9DGG5K0BD3',
   },
   algolia: {
     appId: 'V051EVLWXE',


### PR DESCRIPTION
With this change, the new target for the analytics logs is the new google analytics account.